### PR TITLE
Causal vs. Mapping Task Routing and Mamba Classification Architecture

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -3,11 +3,13 @@ from datetime import datetime
 from pathlib import Path
 import json
 from src.utils.logging import get_logger
+from typing import Literal
 
 logger = get_logger(__name__)
 
 BASE_SEQ_LEN_NORMAL = 10063
 BASE_SEQ_LEN_SPACES = 13077
+
 
 @dataclass
 class MambaConfig:
@@ -161,6 +163,7 @@ class Config:
 
     """
 
+    task: Literal["causal", "mapping"] = "causal"
     use_spaces: bool = False
     device: str = "cuda"
 
@@ -208,20 +211,22 @@ class Config:
     def tokenized_dir(self) -> Path:
         """Dynamic path based on whether we use spaces or not."""
         suffix = "spaced" if self.use_spaces else "normal"
+        suffix += "_mapping" if self.task == "mapping" else ""
         return self.data_dir / f"tokenized_{suffix}"
 
     @property
     def max_len(self) -> int:
         """Max len based on with or without spaces."""
-        return (
-            BASE_SEQ_LEN_SPACES * 2 + 3 + self.buffer if self.use_spaces
-            else BASE_SEQ_LEN_NORMAL * 2 + 3 + self.buffer
-        )
+        base = BASE_SEQ_LEN_SPACES if self.use_spaces else BASE_SEQ_LEN_NORMAL
+        if self.task == "mapping":
+            return base + 2 + self.buffer
+        return base * 2 + 3 + self.buffer
 
     @property
     def save_path(self) -> Path:
         """Dynamic outputs dir based on timestamp and whether we use spaces or not."""
         mode = "spaces" if self.use_spaces else "normal"
+        mode += "_mapping" if self.task == "mapping" else ""
         return self.outputs_dir / f"{mode}_{self._timestamp}"
 
     def load_homophones(self, homophone_file: str = "metadata.json") -> None:

--- a/src/engine/trainer.py
+++ b/src/engine/trainer.py
@@ -3,12 +3,44 @@ from pathlib import Path
 from transformers import Trainer, TrainingArguments
 from transformers.trainer_utils import get_last_checkpoint
 from src.models.mamba import get_model
+from src.models.mamba_mapping import get_mapping_model
 from src.data.dataset import CipherPlainData
 from src.data.pad_collator import PadCollator
 from src.config import Config
 from src.utils.logging import get_logger
+from transformers import EvalPrediction
+import numpy as np
 
 logger = get_logger(__name__)
+
+
+def compute_mapping_metrics(eval_pred: EvalPrediction) -> dict[str, float]:
+    """Calculate accuracy for the mapping classification task.
+
+    Args:
+        eval_pred (EvalPrediction): The evaluation prediction object.
+
+    Returns:
+        dict[str, float]: A dictionary containing the accuracy metric.
+
+    """
+    logits, labels = eval_pred.predictions, eval_pred.label_ids
+
+    if isinstance(logits, tuple):
+        logits = logits[0]
+    if isinstance(labels, tuple):
+        labels = labels[0]
+
+    preds = np.argmax(logits, axis=-1).flatten()
+    labels = labels.flatten()
+
+    mask = labels != -100
+    valid_preds = preds[mask]
+    valid_labels = labels[mask]
+
+    if len(valid_labels) == 0:
+        return {"accuracy": 0.0}
+    return {"accuracy": float((valid_preds == valid_labels).mean())}
 
 
 class MambaTrainer:
@@ -61,13 +93,30 @@ class MambaTrainer:
             f"Fast Path is {mamba2_mod.is_fast_path_available}",
         )
         dataset_path = self.cfg.tokenized_dir
-        self.model = get_model(config.mamba_config)
+        dataset_path = self.cfg.tokenized_dir
+
+        if self.cfg.task == "mapping":
+            self.model = get_mapping_model(config.mamba_config)
+            self.compute_metrics = compute_mapping_metrics
+            self.best_metric = "eval_accuracy"
+            self.greater_is_better = True
+        elif self.cfg.task == "causal":
+            self.model = get_model(config.mamba_config)
+            self.compute_metrics = None
+            self.best_metric = "eval_loss"
+            self.greater_is_better = False
+        else:
+            raise ValueError(
+                f"Unknown task type: {self.cfg.task}. Use 'causal' or 'mapping'.",
+            )
+
         self.collator = PadCollator(pad_token_id=config.pad_token_id)
         self.train_ds = CipherPlainData(dataset_path, split="Training")
         self.eval_ds = CipherPlainData(dataset_path, split="Validation")
+
         self.trainer = self._setup_trainer()
 
-    def _inject_mamba2_kernels(self) -> None: # pragma: no cover
+    def _inject_mamba2_kernels(self) -> None:  # pragma: no cover
         """Force-injects Mamba2 CUDA kernels."""
         try:
             import transformers.models.mamba2.modeling_mamba2 as mamba2_mod
@@ -123,8 +172,8 @@ class MambaTrainer:
             # Checkpointing
             save_total_limit=2,
             load_best_model_at_end=True,
-            metric_for_best_model="eval_loss",
-            greater_is_better=False,
+            metric_for_best_model=self.best_metric,
+            greater_is_better=self.greater_is_better,
             dataloader_num_workers=4,
             dataloader_pin_memory=True,
         )
@@ -135,6 +184,7 @@ class MambaTrainer:
             train_dataset=self.train_ds,
             eval_dataset=self.eval_ds,
             data_collator=self.collator,
+            compute_metrics=self.compute_metrics,
         )
 
     def _load_config(self, current_config: Config, checkpoint_path: str) -> Config:

--- a/src/models/mamba_mapping.py
+++ b/src/models/mamba_mapping.py
@@ -1,0 +1,130 @@
+from dataclasses import asdict
+import torch
+import torch.nn as nn
+from transformers import Mamba2Config, Mamba2Model
+from transformers.modeling_outputs import SequenceClassifierOutput
+from src.config import MambaConfig
+from src.utils.logging import get_logger
+from typing import Any
+
+logger = get_logger(__name__)
+
+
+class Mamba2ForMapping(nn.Module):
+    """Custom Mamba2 model for mapping prediction (Token Classification).
+
+    This model passes the sequence through the causal Mamba2 backbone,
+    pools the hidden states for each unique cipher symbol, and passes
+    them through a linear classification head to predict the English letter.
+
+    Attributes:
+        config (Mamba2Config): The Mamba2 configuration object.
+        num_labels (int): The number of labels in the classification task.
+        mamba2 (Mamba2Model): The Mamba2 backbone model.
+        classifier (nn.Linear): The linear classification head.
+
+    """
+
+    def __init__(self, config: Mamba2Config, num_labels: int = 26) -> None:
+        """Initialize the Mamba2 model with the provided configuration.
+
+        Args:
+            config (Mamba2Config): The Mamba2 configuration object.
+            num_labels (int, optional): The number of labels in the classification task.
+                Defaults to 26.
+
+        """
+        super().__init__()
+        self.num_labels = num_labels
+        self.config = config
+
+        self.mamba2 = Mamba2Model(config)
+        self.classifier = nn.Linear(config.hidden_size, num_labels)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        labels: torch.Tensor | None = None,
+        **kwargs: dict[str, Any],
+    ) -> SequenceClassifierOutput:
+        """Forward pass through the Mamba2 model.
+
+        This method processes the input sequence through the causal backbone,
+        pools the hidden states for each unique cipher symbol, and passes
+        them through a linear classification head to predict the English letter.
+
+        Args:
+            input_ids (torch.Tensor): The input sequence of token IDs.
+            labels (torch.Tensor | None, optional): The target labels for the
+                classification task. Defaults to None.
+            **kwargs: Additional keyword arguments to pass to the causal backbone.
+
+        Returns:
+            SequenceClassifierOutput: The output of the classification head.
+
+        """
+        outputs = self.mamba2(input_ids=input_ids, **kwargs)
+        hidden_states = outputs.last_hidden_state
+
+        batch_size = input_ids.size(0)
+        pooled_logits_list = []
+        aligned_labels_list = []
+
+        for b in range(batch_size):
+            seq_ids = input_ids[b]
+            seq_hidden = hidden_states[b]
+
+            unique_symbols = torch.unique(seq_ids)
+            unique_symbols = unique_symbols[unique_symbols > 0]
+
+            pooled_vectors = [
+                seq_hidden[seq_ids == symbol].mean(dim=0) for symbol in unique_symbols
+            ]
+
+            pooled_tensor = torch.stack(pooled_vectors)
+
+            logits = self.classifier(pooled_tensor)
+            pooled_logits_list.append(logits)
+
+            if labels is not None:
+                num_symbols = logits.size(0)
+                aligned_labels_list.append(labels[b][:num_symbols])
+
+        final_logits = torch.cat(pooled_logits_list, dim=0)
+
+        loss = None
+        if labels is not None and aligned_labels_list:
+            final_labels = torch.cat(aligned_labels_list, dim=0)
+
+            loss_fct = nn.CrossEntropyLoss()
+            loss = loss_fct(final_logits, final_labels.to(final_logits.device))
+
+        return SequenceClassifierOutput(
+            loss=loss,
+            logits=final_logits,  # type: ignore
+            hidden_states=outputs.hidden_states,
+        )
+
+
+def get_mapping_model(config: MambaConfig) -> Mamba2ForMapping:
+    """Initialize a Mamba2 Mapping model with parameters defined in the config.
+
+    Args:
+        config (MambaConfig): The Mamba2 configuration object.
+
+    Returns:
+        Mamba2ForMapping: The initialized Mamba2 Mapping model.
+
+    """
+    m_dict = asdict(config)
+
+    mamba2_config = Mamba2Config(**m_dict)
+    mamba2_config.torch_dtype = torch.bfloat16
+
+    model = Mamba2ForMapping(mamba2_config, num_labels=26)
+
+    logger.info("Mamba2 Mapping Model loaded!")
+    num_params = sum(p.numel() for p in model.parameters())
+    logger.info(f"Parameters:       {num_params:,}")
+
+    return model

--- a/src/train.py
+++ b/src/train.py
@@ -5,8 +5,9 @@ from src.engine.trainer import MambaTrainer
 
 os.environ["PYTORCH_ALLOC_CONF"] = "expandable_segments:True"
 
-def main() -> None:
-    """Begin the training process."""
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
     parser = argparse.ArgumentParser()
     parser.add_argument("--spaces", action="store_true")
     parser.add_argument(
@@ -15,13 +16,28 @@ def main() -> None:
         const=True,
         help="Resume latest or specify a folder",
     )
-    cmd_args = parser.parse_args()
+    parser.add_argument(
+        "--task",
+        choices=["causal", "mapping"],
+        default="causal",
+        help="The task to train on",
+    )
+    return parser.parse_args()
 
-    config = Config(use_spaces=cmd_args.spaces)
+
+def main() -> None:
+    """Begin the training process."""
+    cmd_args = parse_args()
+
+    config = Config(
+        use_spaces=cmd_args.spaces,
+        task=cmd_args.task,
+    )
     config.load_homophones()
 
     trainer = MambaTrainer(config, resume=cmd_args.resume)
     trainer.run()
+
 
 if __name__ == "__main__":
     main()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -17,6 +17,7 @@ modules_to_mock = [
     "causal_conv1d.causal_conv1d_interface",
     "transformers",
     "transformers.trainer_utils",
+    "transformers.modeling_outputs",
     "datasets"
 ]
 

--- a/test/engine/test_trainer.py
+++ b/test/engine/test_trainer.py
@@ -2,7 +2,7 @@ import json
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
@@ -25,6 +25,7 @@ class SchedulerConfig:
 class MockConfig:
     """Dummy configuration structure mimicking the real Config."""
 
+    task: Literal["causal", "mapping"]
     save_path: str
     outputs_dir: str
     use_spaces: bool
@@ -43,6 +44,7 @@ class MockConfig:
 def base_config(tmp_path: Path) -> MockConfig:
     """Provides a clean instance of MockConfig for each test."""
     return MockConfig(
+        task="causal",
         save_path=str(tmp_path / "save"),
         outputs_dir=str(tmp_path / "outputs"),
         use_spaces=False,
@@ -170,6 +172,7 @@ def test_setup_trainer(
         args=mock_args.return_value,
         train_dataset=trainer_instance.train_ds,
         eval_dataset=trainer_instance.eval_ds,
+        compute_metrics=trainer_instance.compute_metrics,
         data_collator=trainer_instance.collator,
     )
 

--- a/test/engine/test_trainer.py
+++ b/test/engine/test_trainer.py
@@ -3,6 +3,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
+import numpy as np
 
 import pytest
 
@@ -40,6 +41,7 @@ class MockConfig:
     eos_token_id: int = 3
     char_offset: int = 4
 
+
 @pytest.fixture
 def base_config(tmp_path: Path) -> MockConfig:
     """Provides a clean instance of MockConfig for each test."""
@@ -52,8 +54,100 @@ def base_config(tmp_path: Path) -> MockConfig:
         pad_token_id=0,
         save_step=10,
         scheduler_config=SchedulerConfig(),
-        tokenized_dir = tmp_path / "tokenized"
+        tokenized_dir=tmp_path / "tokenized",
     )
+
+
+@dataclass
+class MockEvalPrediction:
+    """
+    Mock prediction object.
+    Matches the Hugging Face EvalPrediction where predictions/labels
+    can be raw arrays or tuples of arrays.
+    """
+
+    predictions: np.ndarray | tuple[np.ndarray, ...]
+    label_ids: np.ndarray | tuple[np.ndarray, ...]
+
+
+@dataclass
+class ComputeMappingMetricsTestCase:
+    """Dataclass for testing compute_mapping_metrics."""
+
+    name: str
+    eval_pred: MockEvalPrediction
+    expected: dict[str, float]
+
+
+def create_mock_logits(classes: list[int]) -> np.ndarray:
+    """Creates a (N, 26) logit matrix where the specified classes are winners."""
+    logits = np.zeros((len(classes), 26))
+    for i, cls in enumerate(classes):
+        valid_cls = max(0, min(cls, 25))
+        logits[i, valid_cls] = 1.0
+    return logits
+
+
+compute_mapping_metrics_cases = [
+    ComputeMappingMetricsTestCase(
+        name="perfect_prediction_standard_array",
+        eval_pred=MockEvalPrediction(
+            predictions=create_mock_logits([0, 1, 2]),
+            label_ids=np.array([0, 1, 2]),
+        ),
+        expected={"accuracy": 1.0},
+    ),
+    ComputeMappingMetricsTestCase(
+        name="tuple_predictions_handling",
+        eval_pred=MockEvalPrediction(
+            # Wrapped in tuple: mimics HF returning (logits, hidden_states)
+            predictions=(create_mock_logits([0, 1, 2]),),
+            label_ids=np.array([0, 1, 2]),
+        ),
+        expected={"accuracy": 1.0},
+    ),
+    ComputeMappingMetricsTestCase(
+        name="both_are_tuples",
+        eval_pred=MockEvalPrediction(
+            predictions=(create_mock_logits([0, 5]),),
+            label_ids=(np.array([0, 1]),),
+        ),
+        # Index 0 matches, Index 1 fails. 1/2 = 0.5
+        expected={"accuracy": 0.5},
+    ),
+    ComputeMappingMetricsTestCase(
+        name="with_ignored_indices_and_tuples",
+        eval_pred=MockEvalPrediction(
+            predictions=(create_mock_logits([0, 5, 10]),),
+            label_ids=(np.array([0, 5, -100]),),
+        ),
+        # Two considered, both correct. 2/2 = 1.0
+        expected={"accuracy": 1.0},
+    ),
+    ComputeMappingMetricsTestCase(
+        name="only_ignored_indices",
+        eval_pred=MockEvalPrediction(
+            predictions=create_mock_logits([0, 5, 10]),
+            label_ids=np.array([-100, -100, -100]),
+        ),
+        # All ignored. 0/3 = 0.0
+        expected={"accuracy": 0.0},
+    ),
+]
+
+
+@pytest.mark.parametrize("case", compute_mapping_metrics_cases, ids=lambda c: c.name)
+def test_compute_mapping_metrics(
+    case: ComputeMappingMetricsTestCase, mocker: Any, base_config: MockConfig
+) -> None:
+    """Tests the compute_mapping_metrics function."""
+    mocker.patch("src.engine.trainer.get_mapping_model", return_value=mocker.Mock())
+    base_config.task = "mapping"
+    trainer_instance = MambaTrainer(base_config, resume=False)  # type: ignore
+    assert trainer_instance.compute_metrics is not None
+    result = trainer_instance.compute_metrics(case.eval_pred)  # type: ignore
+
+    assert result == case.expected
 
 
 @pytest.fixture(autouse=True)
@@ -78,7 +172,9 @@ def mock_dependencies(mocker: Any) -> dict[str, Any]:
         "ckpt": mocker.patch(
             "src.engine.trainer.get_last_checkpoint", return_value=None
         ),
-        "inject": mocker.patch("src.engine.trainer.MambaTrainer._inject_mamba2_kernels"),
+        "inject": mocker.patch(
+            "src.engine.trainer.MambaTrainer._inject_mamba2_kernels"
+        ),
     }
 
 
@@ -97,18 +193,29 @@ class InitTestCase:
     name: str
     resume: bool | str
     has_checkpoint: bool
+    task: str = "causal"
+    exception: Exception | None = None
 
 
 init_cases = [
     InitTestCase("new_run", False, False),
     InitTestCase("resume_no_ckpt", True, False),
     InitTestCase("resume_with_ckpt", True, True),
+    InitTestCase(
+        "resume_with_exception",
+        True,
+        False,
+        "wrong",
+        ValueError("Unknown task type: wrong. Use 'causal' or 'mapping'."),
+    ),
 ]
+
 
 @pytest.fixture
 def config_tmp(tmp_path: Path, base_config: MockConfig) -> tuple[MockConfig, Path]:
     """Creates a temporary config and outputs directory."""
     return base_config, tmp_path
+
 
 @pytest.mark.parametrize("case", init_cases, ids=lambda c: c.name)
 def test_init(
@@ -119,6 +226,7 @@ def test_init(
 ) -> None:
     """Tests the initialization logic of MambaTrainer including conditional resume paths."""
     base_config, tmp_path = config_tmp
+    base_config.task = case.task  # type: ignore
     mock_resolve = mocker.patch.object(
         MambaTrainer, "_resolve_resume_path", return_value=tmp_path / "mock_dir"
     )
@@ -135,6 +243,12 @@ def test_init(
         )
     else:
         mocker.patch("src.engine.trainer.get_last_checkpoint", return_value=None)
+
+    if case.exception:
+        with pytest.raises(Exception) as exc_info:
+            MambaTrainer(base_config, resume=case.resume)  # type: ignore
+        assert str(exc_info.value) == str(case.exception)
+        return
 
     trainer = MambaTrainer(base_config, resume=case.resume)  # type: ignore
 

--- a/test/models/test_mamba_mapping.py
+++ b/test/models/test_mamba_mapping.py
@@ -1,0 +1,171 @@
+import pytest
+import torch
+import torch.nn as nn
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+from src.models.mamba_mapping import Mamba2ForMapping, get_mapping_model
+
+MODULE_PATH = "src.models.mamba_mapping"
+
+
+@dataclass
+class DummyMambaConfig:
+    """Mock configuration to satisfy the asdict() call in the factory."""
+
+    hidden_size: int = 16
+    num_hidden_layers: int = 1
+    vocab_size: int = 100
+    n_groups: int = 1
+
+
+@dataclass
+class DummyOutput:
+    """A real object to replace the globally mocked SequenceClassifierOutput."""
+
+    loss: Any = None
+    logits: Any = None
+    hidden_states: Any = None
+
+
+@pytest.fixture(autouse=True)
+def unmock_sequence_output(mocker: Any) -> None:
+    """
+    Because the test environment globally mocks `transformers`,
+    we must inject a real dataclass into the module's namespace
+    so our tensors don't get swallowed into a MagicMock at the end.
+    """
+    mocker.patch(f"{MODULE_PATH}.SequenceClassifierOutput", DummyOutput)
+
+
+@dataclass
+class ForwardTestCase:
+    """Dataclass for clean forward pass parameterization."""
+
+    name: str
+    input_ids: torch.Tensor
+    labels: torch.Tensor | None
+    expected_logits_size: int
+    has_loss: bool
+
+
+def get_forward_cases() -> list[ForwardTestCase]:
+    return [
+        ForwardTestCase(
+            name="inference_no_labels",
+            input_ids=torch.tensor([[1, 2, 0]]),
+            labels=None,
+            expected_logits_size=2,
+            has_loss=False,
+        ),
+        ForwardTestCase(
+            name="training_with_labels",
+            input_ids=torch.tensor([[1, 2, 3]]),
+            labels=torch.tensor([[10, 11, 12]]),
+            expected_logits_size=3,
+            has_loss=True,
+        ),
+        ForwardTestCase(
+            name="multi_batch_and_duplicates",
+            input_ids=torch.tensor([[1, 1, 2, 0], [3, 4, 0, 0]]),
+            labels=torch.tensor([[10, 11, -100], [12, 13, -100]]),
+            expected_logits_size=4,
+            has_loss=True,
+        ),
+    ]
+
+
+@pytest.fixture
+def base_config() -> MagicMock:
+    """
+    Provides a completely isolated mock configuration.
+    This bypasses any global transformers mocks in the environment.
+    """
+    config = MagicMock()
+    config.hidden_size = 16
+    config.num_hidden_layers = 1
+    config.vocab_size = 100
+    return config
+
+
+class TestMamba2ForMapping:
+    """Test suite for the Mamba2ForMapping architecture."""
+
+    def test_initialization(self, base_config: MagicMock) -> None:
+        """Verifies the classification head scales cleanly from the config."""
+        model = Mamba2ForMapping(base_config, num_labels=26)
+
+        assert model.num_labels == 26
+        assert isinstance(model.classifier, nn.Linear)
+        assert model.classifier.in_features == 16
+        assert model.classifier.out_features == 26
+
+    @pytest.mark.parametrize("case", get_forward_cases(), ids=lambda c: c.name)
+    def test_forward_pass(
+        self,
+        case: ForwardTestCase,
+        base_config: MagicMock,
+    ) -> None:
+        """Verifies tensor shapes, label alignment, and loss presence."""
+        model = Mamba2ForMapping(base_config, num_labels=26)
+
+        batch_size, seq_len = case.input_ids.shape
+        real_hidden_states = torch.randn(batch_size, seq_len, 16)
+
+        mock_outputs = MagicMock()
+        mock_outputs.last_hidden_state = real_hidden_states
+        mock_outputs.hidden_states = None
+        model.mamba2 = MagicMock(return_value=mock_outputs)
+
+        output = model(input_ids=case.input_ids, labels=case.labels)
+
+        assert output.logits.shape == (case.expected_logits_size, 26)
+
+        if case.has_loss:
+            assert output.loss is not None
+            assert isinstance(output.loss, torch.Tensor)
+            assert output.loss.ndim == 0
+        else:
+            assert output.loss is None
+
+    def test_pooling_mathematics(self, base_config: MagicMock) -> None:
+        """Mathematically proves the hidden states are correctly mean-pooled."""
+        model = Mamba2ForMapping(base_config, num_labels=26)
+
+        input_ids = torch.tensor([[1, 1]])
+
+        real_hidden_states = torch.ones(1, 2, 16)
+        real_hidden_states[0, 1, :] = 3.0
+
+        mock_outputs = MagicMock()
+        mock_outputs.last_hidden_state = real_hidden_states
+        model.mamba2 = MagicMock(return_value=mock_outputs)
+
+        output = model(input_ids=input_ids)
+
+        expected_pooled_tensor = torch.full((1, 16), 2.0)
+        expected_logits = model.classifier(expected_pooled_tensor)
+
+        torch.testing.assert_close(output.logits, expected_logits)
+
+
+def test_get_mapping_model(mocker: Any) -> None:
+    """Verifies the factory function applies correct types and logs parameters."""
+    mock_logger = mocker.patch(f"{MODULE_PATH}.logger")
+
+    class IsolatedConfig:
+        def __init__(self, **kwargs: Any):
+            self.__dict__.update(kwargs)
+
+    mocker.patch(f"{MODULE_PATH}.Mamba2Config", IsolatedConfig)
+    mocker.patch(f"{MODULE_PATH}.Mamba2Model")
+
+    config = DummyMambaConfig(hidden_size=32)
+    model = get_mapping_model(config)  # type: ignore
+
+    assert model.config.hidden_size == 32
+    assert model.config.torch_dtype == torch.bfloat16
+
+    assert mock_logger.info.call_count == 2
+    mock_logger.info.assert_any_call("Mamba2 Mapping Model loaded!")

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,14 +1,21 @@
 import pytest
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
-from src.config import Config, MambaConfig, CosineSchedulerConfig
+from src.config import (
+    Config,
+    MambaConfig,
+    CosineSchedulerConfig,
+    BASE_SEQ_LEN_NORMAL,
+    BASE_SEQ_LEN_SPACES,
+)
 
 
 @dataclass
 class SuccessTestCase:
     """Dataclass defining parameters for successful config initialization."""
 
+    task: Literal["causal", "mapping"]
     use_spaces: bool
     mock_json: str
     expected_suffix: str
@@ -34,6 +41,7 @@ class FailureTestCase:
     "tc",
     [
         SuccessTestCase(
+            task="causal",
             use_spaces=False,
             mock_json='{"max_symbol_id": 100}',
             expected_suffix="normal",
@@ -42,20 +50,21 @@ class FailureTestCase:
             expected_eos_token_id=104,
             expected_pad_token_id=0,
             expected_vocab_size=141,
-            expected_max_len=20139,
+            expected_max_len=BASE_SEQ_LEN_NORMAL * 2 + 3 + 10,
             expected_save_mode="normal",
         ),
         SuccessTestCase(
+            task="mapping",
             use_spaces=True,
             mock_json='{"max_symbol_id": 2503}',
-            expected_suffix="spaced",
+            expected_suffix="spaced_mapping",
             expected_unique=2503,
             expected_sep_token_id=2504,
             expected_eos_token_id=2507,
             expected_pad_token_id=0,
             expected_vocab_size=2544,
-            expected_max_len=26167,
-            expected_save_mode="spaces",
+            expected_max_len=BASE_SEQ_LEN_SPACES + 2+ 10,
+            expected_save_mode="spaces_mapping",
         ),
     ],
     ids=lambda tc: f"use_spaces_{tc.use_spaces}",
@@ -64,7 +73,7 @@ def test_config_initialization_success(tc: SuccessTestCase, mocker: Any) -> None
     """Verifies successful loading of properties, dynamic vocabulary sizing, and paths."""
     mocker.patch("builtins.open", mocker.mock_open(read_data=tc.mock_json))
 
-    cfg = Config(use_spaces=tc.use_spaces)
+    cfg = Config(use_spaces=tc.use_spaces, task=tc.task)
 
     assert tc.expected_suffix in str(cfg.tokenized_dir)
     assert cfg.unique_homophones == tc.expected_unique

--- a/test/test_train.py
+++ b/test/test_train.py
@@ -10,6 +10,7 @@ class TestTrainScript:
 
         mock_args = MagicMock()
         mock_args.spaces = True
+        mock_args.task = "causal"
         mock_args.resume = True
         mock_parse_args.return_value = mock_args
 
@@ -17,7 +18,7 @@ class TestTrainScript:
 
         main()
 
-        mock_config_cls.assert_called_once_with(use_spaces=True)
+        mock_config_cls.assert_called_once_with(use_spaces=True, task="causal")
 
         mock_config_instance.load_homophones.assert_called_once()
 


### PR DESCRIPTION
## Description
This PR fundamentally updates the training pipeline to support dual-task routing: the existing Generative Causal task, and the new Classification Mapping task. It integrates a new `Mamba2ForMapping` architecture, enabling dynamic routing of dataset parameters, model selection, and metric evaluation depending on the CLI `--task` flag.

## Key Changes

### 1. Dual-Task Architecture Integration (`src/config.py`, `src/train.py`, `src/engine/trainer.py`)
* **Dynamic Config & Data Routing:** `Config` now accepts a `task` literal (`causal` or `mapping`). Length calculations and output directory suffixes are computed dynamically to guarantee task-specific models and tokenized datasets do not overwrite one another.
* **Mamba Mapping Model (`Mamba2ForMapping`):** Added a new architecture class that passes the input sequence through the Mamba2 backbone, extracts specific token indices, applies mean pooling for each unique symbol, and routes to a linear classification head.
* **Trainer Metric Injection:** The `MambaTrainer` now dynamically assigns `.compute_metrics` and `.best_metric` targets. It uses `eval_loss` for sequence generation and `eval_accuracy` (via a newly added masking metrics calculator) for token classification.

### 2. Test Suite Expansion (`test/models/test_mamba_mapping.py`, `test/engine/test_trainer.py`, `test/test_config.py`)
* **Dependency Injection:** Tests evaluate the pure mathematical transformations of `Mamba2ForMapping` by injecting isolated configurations and mock outputs, bypassing brittle global `transformers` mocking.
* **Mathematical Proofs:** Verified mean-pooling logic for the Mamba mapping classification head.
* **Metric Masking Verification:** Added rigorous parametrization to test `compute_mapping_metrics`, ensuring `-100` boundary tokens are accurately filtered out of accuracy calculations.
* **Routing Validation:** Verified that `Config` bounds and string formatting dynamically adjust lengths and file paths per task.